### PR TITLE
Antonioirlandes/split load files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sting-builder",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Sting is a multilanguage builder for Backbone Applicactions.",
   "main": "src/sting.js",
   "dependencies": {

--- a/src/build.js
+++ b/src/build.js
@@ -247,7 +247,8 @@ exports.buildHTML = function (opts){
 		templateString = combineFilesTemplate(templateFiles,opts.templateFolder);
 		index = fs.readFileSync(opts.templateFolder[0] +"/index.html", "utf8"),
 		// Check out if exist a "main-block" in load files
-		indexMainBlock = utils.getStringIndexIntoArray(jsFiles, tagMainBlock);
+		indexMainBlock = utils.getStringIndexIntoArray(jsFiles, tagMainBlock),
+		hasMainBlock = (indexMainBlock > -1);
 
 	if (lang){
 		var translate = require("./translate.js")(opts.i18n);
@@ -276,18 +277,20 @@ exports.buildHTML = function (opts){
 
 	if (debug){
 		// Remove from files the tag value tagMainBlock
-		if (indexMainBlock > -1) {
+		if (hasMainBlock) {
 			jsFiles[indexMainBlock] = jsFiles[indexMainBlock].replace(tagMainBlock, '')
 		}
 
 		for (var i=0; i < jsFiles.length; i++){
 			var prefix = opts.relativePath ? opts.relativePath : '';
-			js += getScriptTag(prefix + "/src/" + jsFiles[i], (indexMainBlock > -1 && indexMainBlock < i)) + "\n";
+			js += getScriptTag(prefix + "/src/" + jsFiles[i], (hasMainBlock && indexMainBlock < i)) + "\n";
 		}
 	} else{
 		var prefix = opts.relativePath ? opts.relativePath : '';
 		js += getScriptTag(prefix + '/js/' + mainJsFile, false);
-		js += getScriptTag(prefix + '/js/' + thirdJsFile, true);
+		if (hasMainBlock) {
+			js += getScriptTag(prefix + '/js/' + thirdJsFile, true);
+		}
 	}
 
 	index = index.replace("</body>",js + "</body>");

--- a/src/build.js
+++ b/src/build.js
@@ -1,8 +1,12 @@
 var fs = require('fs'),
-    jshint = require('jshint'),
-	UglifyCSS = require('uglifycss'),
-	utils = require("./utils.js"),
-  babel = require("babel-core");;
+		jshint = require('jshint'),
+		UglifyCSS = require('uglifycss'),
+		utils = require("./utils.js"),
+		babel = require("babel-core"),
+		// To split the files
+		mainJsFile = 'main.min.js',
+		thirdJsFile = 'third.min.js',
+		tagMainBlock = '@finish-main-block';
 
 function combineFilesTemplate(files,templateFolders) {
 	var content = '';
@@ -33,51 +37,51 @@ exports.buildJS = function (opts) {
 	console.log("-------");
 
 	var files = utils.getFiles(opts.files),
-		targetStr = "";
+			mainFiles = [],
+			thirdFiles = [],
+			// Check out if exist a "main-block" in load files
+			indexMainBlock = utils.getStringIndexIntoArray(files, tagMainBlock);
 
-	// var localopts = {
-	// 	"warnings" : true,
-	// };
-  //
-	// if (opts.outSourceMap){
-	// 	localopts["outSourceMap"] = opts.outSourceMap;
-	// 	localopts["sourceRoot"] = "/src";
-	// }
-  //
-	// if (opts.sourceRoot) {
-	// 	localopts["sourceRoot"] = opts.sourceRoot;
-	// }
-  process.env.BABEL_ENV='production';
+	// Set which are the files to will compose the JS files
+	if (indexMainBlock > -1) {
+		files[indexMainBlock] = files[indexMainBlock].replace(tagMainBlock, '');// Remove from files the tag value tagMainBlock
+		mainFiles = files.slice(0, (indexMainBlock + 1)) // Files to "main.min.js" file
+		thirdFiles = files.slice((indexMainBlock + 1)) // Files to "third.min.js" file
+	} else {
+		mainFiles = files // Files to "main.min.js" file
+	}
 
-  var code = utils.combineFiles(files);
-	var result = babel.transform(code, {
-    /*"presets": [
-      ["env", {
-        "targets": {
-          "chrome": 52
-        }
-      }]
-    ],*/
-    "presets": ["env"],
-    "env": {
-      "production": {
-        "presets": ["babili"]
-      }
-    }
-  });
-  ///console.log(result.code);
+	process.env.BABEL_ENV='production';
 
-	var path = opts.outputPath + "/main.min.js";
-	fs.writeFileSync(path, result.code);
+	// Create the different JS files
+	if (mainFiles.length > 0) {
+		createMinFile(mainFiles, mainJsFile)
+	}
 
-	// if (opts.outSourceMap){
-	// 	console.log("Writing " + localopts["outSourceMap"]);
-	// 	var path = opts.outputPath + "/" + localopts["outSourceMap"];
-	// 	fs.writeFileSync(path, result.map);
-	// }
+	if (thirdFiles.length > 0) {
+		createMinFile(thirdFiles, thirdJsFile)
+	}
+
+	/**
+	 * Create new JS minified file 
+	 * @param {Array} files - files composes the minified file
+	 * @param {String} name - name file
+	 */
+	function createMinFile(files, name) {
+		var code = utils.combineFiles(files);
+		var result = babel.transform(code, {
+			"presets": ["env"],
+			"env": {
+				"production": {
+					"presets": ["babili"]
+				}
+			}
+		});
+		var path = opts.outputPath + '/' + name;
+		fs.writeFileSync(path, result.code);
+	}
 
 	console.log("Building javascript code completed successfully");
-
 };
 
 
@@ -219,8 +223,18 @@ function loadEnvVarsFile(inputFile) {
 	});
 }
 
-function getScriptTag(file){
-	return "<script type='text/javascript' src='" + file + "'></script>";
+/**
+ * Get the "script" tag with the correct "type" and "src" attributte
+ * @param {String} file - name file
+ * @param {Boolean} isBlocked - this file will be blocked in initial load?
+ * @return {String} - string tag
+ */
+function getScriptTag(file, isBlocked){
+	var currentType = isBlocked
+		? 'javascript/blocked'
+		: 'text/javascript';
+
+	return "<script type='" + currentType + "' src='" + file + "'></script>";
 }
 
 exports.buildHTML = function (opts){
@@ -231,7 +245,9 @@ exports.buildHTML = function (opts){
 		debug = opts.debug,
     compress = opts.compress===false ? false: true,
 		templateString = combineFilesTemplate(templateFiles,opts.templateFolder);
-		index = fs.readFileSync(opts.templateFolder[0] +"/index.html", "utf8");
+		index = fs.readFileSync(opts.templateFolder[0] +"/index.html", "utf8"),
+		// Check out if exist a "main-block" in load files
+		indexMainBlock = utils.getStringIndexIntoArray(jsFiles, tagMainBlock);
 
 	if (lang){
 		var translate = require("./translate.js")(opts.i18n);
@@ -259,17 +275,19 @@ exports.buildHTML = function (opts){
 	var js = "";
 
 	if (debug){
-		for (var i=0;i<jsFiles.length;i++){
-			//var f = typeof jsFiles[i]=="object" ? jsFiles[i].src : jsFiles[i];
-			var prefix = opts.relativePath ? opts.relativePath : '';
-			js += getScriptTag(prefix + "/src/" + jsFiles[i]) + "\n";
+		// Remove from files the tag value tagMainBlock
+		if (indexMainBlock > -1) {
+			jsFiles[indexMainBlock] = jsFiles[indexMainBlock].replace(tagMainBlock, '')
 		}
-	}
-	else{
 
+		for (var i=0; i < jsFiles.length; i++){
+			var prefix = opts.relativePath ? opts.relativePath : '';
+			js += getScriptTag(prefix + "/src/" + jsFiles[i], (indexMainBlock > -1 && indexMainBlock < i)) + "\n";
+		}
+	} else{
 		var prefix = opts.relativePath ? opts.relativePath : '';
-
-		js += getScriptTag(prefix + "/js/main.min.js");
+		js += getScriptTag(prefix + '/js/' + mainJsFile, false);
+		js += getScriptTag(prefix + '/js/' + thirdJsFile, true);
 	}
 
 	index = index.replace("</body>",js + "</body>");

--- a/src/sting.js
+++ b/src/sting.js
@@ -1,6 +1,5 @@
 var build = require("./build.js"),
-	utils = require("./utils.js"),
-	exec = require("child_process").exec;
+		utils = require("./utils.js");
 
 function make(opts){
 	if (!opts){
@@ -47,18 +46,17 @@ function make(opts){
 	utils.createDirIfNotExist(opts.outputPath + "/fonts");
 
 	var htaccess = "RewriteEngine On\n" +
-					"RewriteCond %{REQUEST_FILENAME} !-f\n" +
-					"RewriteCond %{REQUEST_FILENAME} !-d\n" +
-					"RewriteCond %{REQUEST_URI} !index\n" +
-					"RewriteRule (.*) index.html [L]\n";
+								"RewriteCond %{REQUEST_FILENAME} !-f\n" +
+								"RewriteCond %{REQUEST_FILENAME} !-d\n" +
+								"RewriteCond %{REQUEST_URI} !index\n" +
+								"RewriteRule (.*) index.html [L]\n";
 
 	var debug = opts && opts.debug===true ? true : false;
 
 	if (!debug){
 		build.buildJS({
 			"files": opts.deps.JS,
-			"outputPath" : opts.outputPath + "/js",
-			"outSourceMap" :  opts.outSourceMap
+			"outputPath" : opts.outputPath + "/js"
 		});
 	}
 
@@ -76,13 +74,12 @@ function make(opts){
 			"config": opts.deps.config,
       "compress": opts.compressHTML
 		});
-	}
-	else{
+	} else {
 
 		var i18n = require("i18n");
 		i18n.configure({
-		    locales:opts.langs,
-		    directory: opts.outputPath + "/locales"
+			locales:opts.langs,
+			directory: opts.outputPath + "/locales"
 		});
 
 		for (var i=0;i< opts.langs.length;i++){
@@ -115,8 +112,6 @@ function make(opts){
 			extraResources(opts);
 		}
 	});
-
-
 }
 
 function extraResources(opts){
@@ -143,13 +138,12 @@ function extraResources(opts){
 		}
 
 	}
-	if (!error)
+	if (!error) {
 		console.log("Build process completed");
+	}
 
 	// Clean build folder
 	utils.deleteBuildFolder();
-
-
 }
 
 exports.make = make;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,10 @@
 var fs = require('fs'),
-	tmp = "build/tmp";
+		tmp = "build/tmp";
 
 function combineFiles (files) {
 	var content = '';
 	for (var i = 0, len = files.length; i < len; i++) {
-		content += fs.readFileSync(files[i], 'utf8') +"\n\n";		
+		content += fs.readFileSync(files[i], 'utf8') +"\n\n";
 	}
 	return content;
 }
@@ -73,3 +73,52 @@ exports.deleteBuildFolder = function(){
 		fs.rmdirSync('build')
 	} 
 }
+
+/**
+ * Search into an array one string and return the index
+ * @param {Array} files - array files
+ * @param {String} stringToMatch - string to find
+ * @return {Number} - index where param "stringToMatch" is
+ */
+function getStringIndexIntoArray(items, stringToMatch){
+	return items.findIndex(function(item) {
+		return item.indexOf(stringToMatch) > -1
+	})
+}
+
+exports.getStringIndexIntoArray = getStringIndexIntoArray;
+
+/**
+ * Generate the "script" tag from different files to load them dynamically
+ * 
+ * IMPORTANT - This function must be implemented (or copy it from here) where
+ * we want to use the option to load the "blocked scripts"
+ *
+ * @param {String} type - <optional> string to identify the script to load
+ */
+function loadBlockedScripts(type) {
+	var currentType = typeof type === 'string'
+		? type
+		: 'javascript/blocked'
+
+	if (document) {
+		var scripts = document.getElementsByTagName('SCRIPT');
+		var scriptsToLoad = [];
+
+		for (var i = 0; i < scripts.length; i++) {
+			if (scripts[i].getAttribute('src') && scripts[i].getAttribute('type') === currentType) {
+				var currentScript = document.createElement('script');
+
+				currentScript.src = scripts[i].getAttribute('src');
+				currentScript.type = 'application/javascript';
+				scriptsToLoad.push(currentScript)
+			}
+		}
+
+		for (var i = 0; i < scriptsToLoad.length; i++) {
+			document.head.appendChild(scriptsToLoad[i]);
+		}
+	}
+};
+
+exports.loadBlockedScripts = loadBlockedScripts;


### PR DESCRIPTION
Ahora es posible dividir en 2 partes ("principal" y "terceros") la carga de todas las librerías JS, que se indican en los ficheros "deps.js". La idea es dividir la carga de los ficheros del núcleo (principal), con los ficheros de los verticales (terceros).

Para conseguir esto, solo hay que hacer 2 cambios:

1. Indicar donde se quiere hacer la división. Para ello, se debe incluir la etiqueta "@finish-main-block" en el fichero que deseemos que sea parte del núcleo principal (este último inclusive). En este caso, me voy al fichero "deps.js" del proyecto (UrboCore-www) y modifico la última inclusión de ficheros JS, dejándola tal que así:

     `srcJS + 'Router.js@finish-main-block'`

2. Indicar en que punto deseo cargar el resto de librerías (terceras), una vez que se ha cumplido la condición deseada. Para ello hago uso de una función (loadBlockedScripts) creada en este mismo paquete y que deberá ser debidamente copiada (u otra función con igual propósito) en el punto donde deseemos cargar el resto de librerías . En el caso particular que os atañe, debemos esperar que la carga de los ficheros de traducción sea completada, una vez que sea así, cargamos el resto de librerías. El código queda algo tal que así:

`    $.getJSON('/locale/' + App.lang + '.json')
      .done(function (locale) {
        var jed = new Jed(locale);
        __ = function(d) {
          return jed.gettext(d);
        }
        App.Utils.loadBlockedScripts()
        App.ini();
      })
      .fail(function() {
        App.Utils.loadBlockedScripts()
        App.ini();
      });
`

En el susodicho caso que no se quiera dividir la carga y no se incluya la etiqueta '@finish-main-block', esta seguirá funcionando igual que hasta ahora.

